### PR TITLE
Add jsdelivr CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ bower install chillout
 
 ### CDN
 
-chillout.js is available on [cdnjs.com](https://cdnjs.com/libraries/chillout).
+chillout.js is available on [jsdelivr.com](https://www.jsdelivr.com/package/npm/chillout) and [cdnjs.com](https://cdnjs.com/libraries/chillout).
 
 ### Usage
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as an alternative to cdnjs.  jsDelivr is the fastest opensource CDN available and has a big network in China too.